### PR TITLE
RD-1010 Fix D+ and grade calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MapTiler Client Changelog
 
+## 3.0.2
+### Bug Fixes
+- Fixes D+ and Grade calculations to fix tooltip error on last datapoint
+
 ## 3.0.0
 ### Other
 - Update with MapTiler SDK v3 (globe)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/elevation-profile-control",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/elevation-profile-control",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Elevation profile control for MapTiler SDK",
   "module": "dist/maptiler-elevation-profile-control.js",
   "types": "dist/maptiler-elevation-profile-control.d.ts",

--- a/src/elevationprofile.ts
+++ b/src/elevationprofile.ts
@@ -733,21 +733,18 @@ export class ElevationProfile {
     this.grade = [];
     let cumulatedDPlus = 0;
 
-    for (let i = 0; i < this.elevatedPositions.length; i += 1) {
+    this.cumulatedDPlus.push(0);
+    for (let i = 1; i < this.elevatedPositions.length; i += 1) {
       const elevation = this.elevatedPositions[i][2];
-
-      if (i > 1) {
-        const elevationPrevious = this.elevatedPositions[i - 1][2];
-        const elevationDelta = elevation - elevationPrevious;
-        const segmentDistance =
-          this.cumulatedDistance[i] - this.cumulatedDistance[i - 1];
-        cumulatedDPlus += Math.max(0, elevationDelta);
-        this.cumulatedDPlus.push(cumulatedDPlus);
-        this.grade.push(((elevationDelta / segmentDistance) * 1000) / 10);
-      }
+      const elevationPrevious = this.elevatedPositions[i - 1][2];
+      const elevationDelta = elevation - elevationPrevious;
+      const segmentDistance =
+        this.cumulatedDistance[i] - this.cumulatedDistance[i - 1];
+      cumulatedDPlus += Math.max(0, elevationDelta);
+      this.cumulatedDPlus.push(cumulatedDPlus);
+      this.grade.push(((elevationDelta / segmentDistance) * 1000) / 10);
     }
     this.grade.push(0);
-    this.cumulatedDPlus.push(cumulatedDPlus);
 
     // Conversion of distance to miles and elevation to feet
     if (this.settings.unit === "imperial") {


### PR DESCRIPTION
## Objective
Fixes RD-1010

## Description
Calculation of D+ and Grade values for each datapoint has been fixed, each datapoint now shows its own correct values and the last datapoint no longer throws error because of missing values.

## Acceptance
Manually tested

## Checklist
- [x] I have added relevant info to the CHANGELOG.md and version in package.json